### PR TITLE
Correction in namp exemple

### DIFF
--- a/ships/namp/usr/pkg/etc/httpd/httpd.conf
+++ b/ships/namp/usr/pkg/etc/httpd/httpd.conf
@@ -142,8 +142,8 @@ LoadModule version_module lib/httpd/mod_version.so
 #LoadModule lbmethod_bytraffic_module lib/httpd/mod_lbmethod_bytraffic.so
 #LoadModule lbmethod_bybusyness_module lib/httpd/mod_lbmethod_bybusyness.so
 #LoadModule lbmethod_heartbeat_module lib/httpd/mod_lbmethod_heartbeat.so
-LoadModule mpm_event_module lib/httpd/mod_mpm_event.so
-#LoadModule mpm_prefork_module lib/httpd/mod_mpm_prefork.so
+#LoadModule mpm_event_module lib/httpd/mod_mpm_event.so
+LoadModule mpm_prefork_module lib/httpd/mod_mpm_prefork.so
 #LoadModule mpm_worker_module lib/httpd/mod_mpm_worker.so
 LoadModule unixd_module lib/httpd/mod_unixd.so
 #LoadModule heartbeat_module lib/httpd/mod_heartbeat.so


### PR DESCRIPTION
Corrected namp exemple to be compatible with php by modifying apache to use mpm_prefork
